### PR TITLE
;;add command improvements

### DIFF
--- a/cmds/add.py
+++ b/cmds/add.py
@@ -4,29 +4,29 @@ from Message import Message
 
 
 def add(message: Message, db: DatabaseManager, overwrite: bool = False) -> str:
-    args = message.args
-    reply = Message(message.reference) if message.reference else None
+	args = message.args
+	reply = Message(message.reference) if message.reference else None
 
-    if len(args) == 1:
-        return constants.WRONG_ARGS_ADD
+	if len(args) == 1:
+		return constants.WRONG_ARGS_ADD
 
-    if len(args) == 2:
-        if reply is None and len(message.message_obj.attachments) == 0:
-            return constants.WRONG_ARGS_ADD
+	if len(args) == 2:
+		if reply is None and len(message.message_obj.attachments) == 0:
+			return constants.WRONG_ARGS_ADD
 
-        original_message = ""
-        if reply:
-            original_message = (getattr(reply, "content", "") or "").strip()
-            original_message += _get_attachments_text(reply)
-        else:
-            original_message = _get_attachments_text(message)
+		original_message = ""
+		if reply:
+			original_message = (getattr(reply, "content", "") or "").strip()
+			original_message += _get_attachments_text(reply)
+		else:
+			original_message = _get_attachments_text(message)
 
-        if not original_message:
-            return constants.EMPTY_MESSAGE
+		if not original_message:
+			return constants.EMPTY_MESSAGE
 
-        return db.store_text(message.author.id, args[1], original_message, overwrite)
+		return db.store_text(message.author.id, args[1], original_message, overwrite)
 
-    return db.store_text(message.author.id, args[1], " ".join(args[2:]), overwrite)
+	return db.store_text(message.author.id, args[1], " ".join(args[2:]), overwrite)
 
 
 def _get_attachments_text(message: Message) -> str:

--- a/cmds/add.py
+++ b/cmds/add.py
@@ -2,42 +2,41 @@ import constants
 from DatabaseManager import DatabaseManager
 from Message import Message
 
-def add(message: Message, db: DatabaseManager, overwrite:bool=False) -> str:
-	args = message.args
-	reply = Message(message.reference) if message.reference else None
-	if len(args) == 1:
-		return constants.WRONG_ARGS_ADD
 
-	if len(args) == 2:
-		if reply is None and len(message.message_obj.attachments) == 0:
-			return constants.WRONG_ARGS_ADD
+def add(message: Message, db: DatabaseManager, overwrite: bool = False) -> str:
+    args = message.args
+    reply = Message(message.reference) if message.reference else None
 
-		if reply:
-			# original_message = reply.resolved.content.strip() or ''
-			original_message = reply.content.strip() or ''
-			original_message += _get_attachments_text(reply)
-		else:
-			original_message = ''
-		original_message += _get_attachments_text(message)
+    if len(args) == 1:
+        return constants.WRONG_ARGS_ADD
 
-		if not original_message:
-			return constants.EMPTY_MESSAGE
+    if len(args) == 2:
+        if reply is None and len(message.message_obj.attachments) == 0:
+            return constants.WRONG_ARGS_ADD
 
-		return db.store_text(message.author.id, args[1], original_message, overwrite)
+        original_message = ""
+        if reply:
+            original_message = (getattr(reply, "content", "") or "").strip()
+            original_message += _get_attachments_text(reply)
+        else:
+            original_message = _get_attachments_text(message)
 
-	return db.store_text(message.author.id, args[1], ' '.join(args[2:]), overwrite)
+        if not original_message:
+            return constants.EMPTY_MESSAGE
+
+        return db.store_text(message.author.id, args[1], original_message, overwrite)
+
+    return db.store_text(message.author.id, args[1], " ".join(args[2:]), overwrite)
+
 
 def _get_attachments_text(message: Message) -> str:
-	text = ''
-	# for i, attachment in enumerate(message.attachments):
-	# 	text += f'[Attachment {i}]({attachment.url}) '
-	# for sticker in message.stickers:
-	# 	text += f'[{sticker.name}]({sticker.url}) '
+    text = ""
 
-	for i, url in enumerate(message.images):
-		text += f'[Image {i}]({url}) '
-	for i, url in enumerate(message.videos):
-		text += f'[Video {i}]({url}) '
-	for i, url in enumerate(message.audios):
-		text += f'[Audio {i}]({url}) '
-	return text
+    for i, url in enumerate(message.images):
+        text += f"[Image {i}]({url}) "
+    for i, url in enumerate(message.videos):
+        text += f"[Video {i}]({url}) "
+    for i, url in enumerate(message.audios):
+        text += f"[Audio {i}]({url}) "
+
+    return text


### PR DESCRIPTION
> Fix duplication in ;;add. Remove unnecessary comments, while setting original_message, ensure reply.content exists, else default to empty string, then strip whitespace, instead of the previous approach.